### PR TITLE
add group_vars from file to returned group vars

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -250,7 +250,20 @@ class InventoryCLI(CLI):
             results[group.name] = {}
             if group.name != 'all':
                 results[group.name]['hosts'] = [h.name for h in sorted(group.hosts, key=attrgetter('name'))]
+
             results[group.name]['vars'] = group.get_vars()
+            if self._new_api:
+                from ansible.plugins import lookup_loader, vars_loader
+                from ansible.utils.vars import combine_vars
+                import os
+
+                for source in self.vm._inventory._sources:
+                    for plugin in vars_loader.all():
+                        results[group.name]['vars'] = combine_vars(
+                            results[group.name]['vars'],
+                            plugin.get_vars(self.loader, os.path.dirname(source), [group])
+                        )
+
             results[group.name]['children'] = []
             for subgroup in sorted(group.child_groups, key=attrgetter('name')):
                 results[group.name]['children'].append(subgroup.name)


### PR DESCRIPTION
This makes the "vars" subsection of a group from the `ansible-inventory` command more comprehensive.

Note that the command will not work correctly right now because I believe that the ansible-inventory branch needs to be rebased to pick up the recent related fix that landed in `devel`.

This addition adds group vars that come from file. Example: https://github.com/AlanCoding/Ansible-inventory-file-examples/tree/master/valid/vars_dirs

Before change:

```json
{
    "_meta": {
        "hostvars": {
            "host1": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }, 
            "host2": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "host2var": "asdf", 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }, 
            "host3": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }
        }
    }, 
    "all": {
        "children": [
            "ungrouped", 
            "usa"
        ]
    }, 
    "atlanta": {
        "hosts": [
            "host1", 
            "host2"
        ]
    }, 
    "raleigh": {
        "hosts": [
            "host2", 
            "host3"
        ]
    }, 
    "southeast": {
        "children": [
            "atlanta", 
            "raleigh"
        ], 
        "vars": {
            "escape_pods": 2, 
            "some_server": "foo.southeast.example.com"
        }
    }, 
    "ungrouped": {}, 
    "usa": {
        "children": [
            "southeast"
        ]
    }
}
```

After change:

```json
{
    "_meta": {
        "hostvars": {
            "host1": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }, 
            "host2": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "host2var": "asdf", 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }, 
            "host3": {
                "escape_pods": 2, 
                "halon_system_timeout": 30, 
                "self_destruct_countdown": 60, 
                "some_server": "foo.southeast.example.com"
            }
        }
    }, 
    "all": {
        "children": [
            "ungrouped", 
            "usa"
        ]
    }, 
    "atlanta": {
        "hosts": [
            "host1", 
            "host2"
        ]
    }, 
    "raleigh": {
        "hosts": [
            "host2", 
            "host3"
        ]
    }, 
    "southeast": {
        "children": [
            "atlanta", 
            "raleigh"
        ], 
        "vars": {
            "escape_pods": 2, 
            "halon_system_timeout": 30, 
            "self_destruct_countdown": 60, 
            "some_server": "foo.southeast.example.com"
        }
    }, 
    "ungrouped": {}, 
    "usa": {
        "children": [
            "southeast"
        ]
    }
}
```