### PR TITLE
use only_exports in inherited vars

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -450,14 +450,15 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         default_vars = combine_vars(default_vars, self._default_vars)
         return default_vars
 
-    def get_inherited_vars(self, dep_chain=None):
+    def get_inherited_vars(self, dep_chain=None, only_exports=False):
         dep_chain = [] if dep_chain is None else dep_chain
 
         inherited_vars = dict()
 
         if dep_chain:
             for parent in dep_chain:
-                inherited_vars = combine_vars(inherited_vars, parent.vars)
+                if not only_exports:
+                    inherited_vars = combine_vars(inherited_vars, parent.vars)
                 inherited_vars = combine_vars(inherited_vars, parent._role_vars)
         return inherited_vars
 
@@ -478,7 +479,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
 
         # get role_vars: from parent objects
         # TODO: is this right precedence for inherited role_vars?
-        all_vars = self.get_inherited_vars(dep_chain)
+        all_vars = self.get_inherited_vars(dep_chain, only_exports=only_exports)
 
         # get exported variables from meta/dependencies
         seen = set()

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -16,3 +16,7 @@ set -eux
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"
+
+
+# ensure vars scope is correct
+ansible-playbook vars_scope.yml -i ../../inventory "$@"

--- a/test/integration/targets/roles/tasks/check_vars.yml
+++ b/test/integration/targets/roles/tasks/check_vars.yml
@@ -3,5 +3,5 @@
 
 - assert:
     that:
-        - item in vars and item in defined or item not in vars and item not in defined # and vars[item] == defined[item]
+        - (item in vars and item in defined and vars[item] == defined[item]) or (item not in vars and item not in defined)
   loop: '{{possible_vars}}'

--- a/test/integration/targets/roles/vars/play.yml
+++ b/test/integration/targets/roles/vars/play.yml
@@ -8,22 +8,19 @@ play_and_import_and_role_vars: play
 play_and_include_and_role_vars: play
 possible_vars:
     - default_only
-    - play_only
-    - play_and_roles
-    - roles_only
-    - import_only
-    - play_and_import
-    - include_only
-    - play_and_include
-    - role_vars_only
-    - play_and_role_vars
-    - play_and_roles_and_role_vars
-    - play_and_import_and_role_vars
-    - play_and_include_and_role_vars
-    - play_and_role_vars_and_role_vars
-    - roles_and_role_vars
-    - play_and_roles_and_role_vars
     - import_and_role_vars
-    - play_and_import_and_role_vars
+    - import_only
     - include_and_role_vars
+    - include_only
+    - play_and_import
+    - play_and_import_and_role_vars
+    - play_and_include
     - play_and_include_and_role_vars
+    - play_and_roles
+    - play_and_roles_and_role_vars
+    - play_and_role_vars
+    - play_and_role_vars_and_role_vars
+    - play_only
+    - roles_and_role_vars
+    - roles_only
+    - role_vars_only

--- a/test/integration/targets/roles/vars_scope.yml
+++ b/test/integration/targets/roles/vars_scope.yml
@@ -12,40 +12,75 @@
         play_and_roles_and_role_vars: roles
         defined:
             default_only: default
-            play_only: play
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
             play_and_import: play
+            play_and_import_and_role_vars: role_vars
             play_and_include: play
-            play_and_role_vars: role_vars
-            roles_only: roles
-            role_vars_only: role_vars
-            roles_and_role_vars: roles
+            play_and_include_and_role_vars: role_vars
             play_and_roles: roles
             play_and_roles_and_role_vars: roles
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: roles
+            roles_only: roles
+            role_vars_only: role_vars
 
   pre_tasks:
     - include_tasks: tasks/check_vars.yml
       vars:
         defined:
             default_only: default
-            play_only: play
-            play_and_roles: play
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
             play_and_import: play
+            play_and_import_and_role_vars: role_vars
             play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
             play_and_role_vars: role_vars
-            play_and_roles_and_role_vars: roles
-            play_and_import_and_role_vars: import
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
             role_vars_only: role_vars
-            roles_and_role_vars: roles
   tasks:
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          default_only: default
+          import_and_role_vars: role_vars
+          include_and_role_vars: role_vars
+          play_and_import: play
+          play_and_import_and_role_vars: role_vars
+          play_and_include: play
+          play_and_include_and_role_vars: role_vars
+          play_and_roles: play
+          play_and_roles_and_role_vars: role_vars
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_only: play
+          roles_and_role_vars: role_vars
+          role_vars_only: role_vars
 
 - name: play and import
   hosts: localhost
-  gather_facts: valse
+  gather_facts: false
   vars_files:
     - vars/play.yml
   tasks:
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          play_and_import: play
+          play_and_import_and_role_vars: play
+          play_and_include: play
+          play_and_include_and_role_vars: play
+          play_and_roles: play
+          play_and_roles_and_role_vars: play
+          play_and_role_vars: play
+          play_only: play
 
     - name: static import
       import_role:
@@ -55,16 +90,58 @@
         import_and_role_vars: import
         play_and_import: import
         play_and_import_and_role_vars: import
+        defined:
+          default_only: default
+          import_and_role_vars: import
+          import_only: import
+          include_and_role_vars: role_vars
+          play_and_import: import
+          play_and_import_and_role_vars: import
+          play_and_include: play
+          play_and_include_and_role_vars: role_vars
+          play_and_roles: play
+          play_and_roles_and_role_vars: role_vars
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_only: play
+          roles_and_role_vars: role_vars
+          role_vars_only: role_vars
 
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          default_only: default
+          import_and_role_vars: role_vars
+          include_and_role_vars: role_vars
+          play_and_import: play
+          play_and_import_and_role_vars: role_vars
+          play_and_include: play
+          play_and_include_and_role_vars: role_vars
+          play_and_roles: play
+          play_and_roles_and_role_vars: role_vars
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_only: play
+          roles_and_role_vars: role_vars
+          role_vars_only: role_vars
 
 - name: play and include
   hosts: localhost
-  gather_facts: valse
+  gather_facts: false
   vars_files:
     - vars/play.yml
   tasks:
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          play_and_import: play
+          play_and_import_and_role_vars: play
+          play_and_include: play
+          play_and_include_and_role_vars: play
+          play_and_roles: play
+          play_and_roles_and_role_vars: play
+          play_and_role_vars: play
+          play_only: play
 
     - name: dynamic include
       include_role:
@@ -74,12 +151,38 @@
         include_and_role_vars: include
         play_and_include: include
         play_and_include_and_role_vars: include
+        defined:
+          default_only: default
+          import_and_role_vars: role_vars
+          include_and_role_vars: include
+          include_only: include
+          play_and_import: play
+          play_and_import_and_role_vars: role_vars
+          play_and_include: include
+          play_and_include_and_role_vars: include
+          play_and_roles: play
+          play_and_roles_and_role_vars: role_vars
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_only: play
+          roles_and_role_vars: role_vars
+          role_vars_only: role_vars
 
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          play_and_import: play
+          play_and_import_and_role_vars: play
+          play_and_include: play
+          play_and_include_and_role_vars: play
+          play_and_roles: play
+          play_and_roles_and_role_vars: play
+          play_and_role_vars: play
+          play_only: play
 
 - name: play and roles and import and include
   hosts: localhost
-  gather_facts: valse
+  gather_facts: false
   vars:
   vars_files:
     - vars/play.yml
@@ -90,12 +193,60 @@
         roles_and_role_vars: roles
         play_and_roles: roles
         play_and_roles_and_role_vars: roles
+        defined:
+          default_only: default
+          import_and_role_vars: role_vars
+          include_and_role_vars: role_vars
+          play_and_import: play
+          play_and_import_and_role_vars: role_vars
+          play_and_include: play
+          play_and_include_and_role_vars: role_vars
+          play_and_roles: roles
+          play_and_roles_and_role_vars: roles
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_only: play
+          roles_and_role_vars: roles
+          roles_only: roles
+          role_vars_only: role_vars
 
   pre_tasks:
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+            default_only: default
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
+            play_and_import: play
+            play_and_import_and_role_vars: role_vars
+            play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars
 
   tasks:
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+            default_only: default
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
+            play_and_import: play
+            play_and_import_and_role_vars: role_vars
+            play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars
 
     - name: static import
       import_role:
@@ -105,8 +256,40 @@
         import_and_role_vars: import
         play_and_import: import
         play_and_import_and_role_vars: import
+        defined:
+            default_only: default
+            import_and_role_vars: import
+            import_only: import
+            include_and_role_vars: role_vars
+            play_and_import: import
+            play_and_import_and_role_vars: import
+            play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars
 
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+            default_only: default
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
+            play_and_import: play
+            play_and_import_and_role_vars: role_vars
+            play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars
 
     - name: dynamic include
       include_role:
@@ -116,5 +299,37 @@
         include_and_role_vars: include
         play_and_include: include
         play_and_include_and_role_vars: include
+        defined:
+            default_only: default
+            import_and_role_vars: role_vars
+            include_and_role_vars: include
+            include_only: include
+            play_and_import: play
+            play_and_import_and_role_vars: role_vars
+            play_and_include: include
+            play_and_include_and_role_vars: include
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars
 
     - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+            default_only: default
+            import_and_role_vars: role_vars
+            include_and_role_vars: role_vars
+            play_and_import: play
+            play_and_import_and_role_vars: role_vars
+            play_and_include: play
+            play_and_include_and_role_vars: role_vars
+            play_and_roles: play
+            play_and_roles_and_role_vars: role_vars
+            play_and_role_vars: role_vars
+            play_and_role_vars_and_role_vars: role_vars
+            play_only: play
+            roles_and_role_vars: role_vars
+            role_vars_only: role_vars

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -48,6 +48,7 @@
           name: a
         vars:
           a_int: "{{ INT_VALUE }}"
+          a_str: "import_role"
 
       - name: "Call role entry point that is defined, but has no spec data"
         import_role:


### PR DESCRIPTION
##### SUMMARY
passes only_exports to inherited vars now too and updated some tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
