### PR TITLE
Cgroup priority

### DIFF
--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -60,7 +60,7 @@ options:
         default: True
         version_added: '2.12'
       priority:
-        description: Set group's priority for fine control of variable precedence
+        description: Set group's priority for fine control of variable precedence.
         type: int
         version_added: '2.16'
   use_extra_vars:

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -448,7 +448,7 @@ class Constructable(object):
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             result_gname = self.inventory.add_group(gname)
                             # Add `ansible_keyed_group_name` to the variables that we can use to template
-                            templar_variables = combine_vars({'ansible_keyed_group_name': result_gname}, variables)
+                            templar_variables = combine_vars(variables, {'ansible_keyed_group_name': result_gname})
                             self.templar.available_variables = templar_variables
                             # Template the group_priority. There are not many variables available at this point,
                             # But what we have should be able to be used here.

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -447,6 +447,8 @@ class Constructable(object):
                                 sep = ''
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             result_gname = self.inventory.add_group(gname)
+                            self.inventory.add_host(host, result_gname)
+
                             # Add `ansible_keyed_group_name` to the variables that we can use to template
                             templar_variables = combine_vars(variables, {'ansible_keyed_group_name': result_gname})
                             self.templar.available_variables = templar_variables
@@ -459,8 +461,6 @@ class Constructable(object):
                                     result_group.set_priority(int(group_priority))
                                 except ValueError as e:
                                     raise AnsibleParserError("Invalid group priority given: %s" % to_native(e))
-
-                            self.inventory.add_host(host, result_gname)
 
                             if raw_parent_name:
                                 parent_name = self._sanitize_group_name(raw_parent_name)

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -454,7 +454,8 @@ class Constructable(object):
                             gname = self._sanitize_group_name('%s%s%s' % (prefix, sep, bare_name))
                             result_gname = self.inventory.add_group(gname)
                             if group_priority is not None:
-                                result_gname.set_priority(group_priority)
+                                result_group = self.inventory.groups.get(result_gname)
+                                result_group.set_priority(group_priority)
 
                             self.inventory.add_host(host, result_gname)
 

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -76,6 +76,14 @@ EXAMPLES = r'''
         # this creates a common parent group for all ec2 availability zones
         - key: placement.availability_zone
           parent_group: all_ec2_zones
+
+        # Assuming that there exist `tags` that are assigned to various servers such as 'stuff', 'things', 'status', etc.
+        # The variable `ansible_keyed_group_name` is exposed to the priority. Its value is the resolved group name once
+        # it's been completely templated.
+        - key: tags
+          prefix: tag
+          default_value: "running"
+          priority: "{{ 10 if 'status' in ansible_keyed_group_name else 50 }}"
 '''
 
 import os

--- a/test/integration/targets/inventory_constructed/invs/3/group_vars/a_keyed_group_priority_3/all.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/group_vars/a_keyed_group_priority_3/all.yml
@@ -1,0 +1,1 @@
+override_priority_3: "a_keyed_group_priority_3"

--- a/test/integration/targets/inventory_constructed/invs/3/group_vars/b_keyed_group_priority_2/all.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/group_vars/b_keyed_group_priority_2/all.yml
@@ -1,0 +1,2 @@
+override_priority_2: "b_keyed_group_priority_2"
+override_priority_3: "b_keyed_group_priority_2"

--- a/test/integration/targets/inventory_constructed/invs/3/group_vars/c_static_group_priority_1/all.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/group_vars/c_static_group_priority_1/all.yml
@@ -1,0 +1,3 @@
+override_priority_1: "c_static_group_priority_1"
+override_priority_2: "c_static_group_priority_1"
+override_priority_3: "c_static_group_priority_1"

--- a/test/integration/targets/inventory_constructed/invs/3/keyed_group_str_default_value_with_priority.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/keyed_group_str_default_value_with_priority.yml
@@ -8,4 +8,4 @@ keyed_groups:
   - key: keyed_group_2
     default_value: "priority_3"
     prefix: a_keyed_group
-    priority: 3
+    priority: '{{ 3 if "priority_3" in ansible_keyed_group_name else 1 }}'

--- a/test/integration/targets/inventory_constructed/invs/3/keyed_group_str_default_value_with_priority.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/keyed_group_str_default_value_with_priority.yml
@@ -1,0 +1,11 @@
+plugin: ansible.builtin.constructed
+keyed_groups:
+  - key: keyed_group_1
+    default_value: "priority_2"
+    prefix: b_keyed_group
+    priority: 2
+
+  - key: keyed_group_2
+    default_value: "priority_3"
+    prefix: a_keyed_group
+    priority: 3

--- a/test/integration/targets/inventory_constructed/invs/3/priority_inventory.yml
+++ b/test/integration/targets/inventory_constructed/invs/3/priority_inventory.yml
@@ -1,0 +1,7 @@
+all:
+  children:
+    c_static_group_priority_1:
+      hosts:
+        host0:
+          keyed_group_1: ""
+          keyed_group_2: ""

--- a/test/integration/targets/inventory_constructed/runme.sh
+++ b/test/integration/targets/inventory_constructed/runme.sh
@@ -73,6 +73,8 @@ grep '"override_priority_1": "c_static_group_priority_1"' out.txt
 # of 2, which should override c_static_group_priority_1. This means that the value from b_keyed_group_priority_2 should return.
 grep '"override_priority_2": "b_keyed_group_priority_2"' out.txt
 # override_priority_3 is set in all the groups, which means the group with the highest priority set should win.
-# Lexicographically, this would otherwise be 2_static_group_priority_1. However, since we set the priority of
+# Lexicographically, this would otherwise be c_static_group_priority_1. However, since we set the priority of
 # a_keyed_group_priority_3 to 3, we will expect it to override the other two groups, and return its variable.
+# Note that a_keyed_group_priority_3 has its priority set with a conditional, so here we are testing our ability
+# to set this priority with a variable, including the `ansible_keyed_group_name` variable that we expose.
 grep '"override_priority_3": "a_keyed_group_priority_3"' out.txt

--- a/test/integration/targets/inventory_constructed/runme.sh
+++ b/test/integration/targets/inventory_constructed/runme.sh
@@ -57,3 +57,22 @@ ansible-inventory -i invs/1/one.yml -i invs/2/constructed.yml --graph | tee out.
 
 grep '@c_lola' out.txt
 grep '@c_group4testing' out.txt
+
+# Testing the priority
+ansible-inventory -i invs/3/priority_inventory.yml -i invs/3/keyed_group_str_default_value_with_priority.yml --list | tee out.txt
+
+# If we expect the variables to be resolved lexicographically, ('c' would override 'b', which would override 'a')
+# then we would expect c_static_group_priority_1 to take precedence.
+# However, setting the priorities here is what we're testing, and is indicated in the names of the groups.
+#
+# If you comment out the priorities of the keyed groups, all of the below will return c_static_group_priority_1
+
+# override_priority_1 is ONLY set in c_static_group_priority_1 - so it should not get overridden by any other group
+grep '"override_priority_1": "c_static_group_priority_1"' out.txt
+# override_priority_2 is set in both c_static_group_priority_1 and b_keyed_group_priority_2 which (as advertised) has a priority
+# of 2, which should override c_static_group_priority_1. This means that the value from b_keyed_group_priority_2 should return.
+grep '"override_priority_2": "b_keyed_group_priority_2"' out.txt
+# override_priority_3 is set in all the groups, which means the group with the highest priority set should win.
+# Lexicographically, this would otherwise be 2_static_group_priority_1. However, since we set the priority of
+# a_keyed_group_priority_3 to 3, we will expect it to override the other two groups, and return its variable.
+grep '"override_priority_3": "a_keyed_group_priority_3"' out.txt


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Fixes functionality of keyed group priority
Adds tests and templating to priority

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Hoping to contribute to https://github.com/ansible/ansible/pull/81603

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below
cd test/integration/targets/inventory_constructed
./runme.sh
[...snip...]
+ ansible-inventory -i invs/3/priority_inventory.yml -i invs/3/keyed_group_str_default_value_with_priority.yml --list
+ tee out.txt
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
{
    "_meta": {
        "hostvars": {
            "host0": {
                "keyed_group_1": "",
                "keyed_group_2": "",
                "override_priority_1": "c_static_group_priority_1",
                "override_priority_2": "b_keyed_group_priority_2",
                "override_priority_3": "a_keyed_group_priority_3"
            }
        }
    },
    "a_keyed_group_priority_3": {
        "hosts": [
            "host0"
        ]
    },
    "all": {
        "children": [
            "ungrouped",
            "c_static_group_priority_1",
            "b_keyed_group_priority_2",
            "a_keyed_group_priority_3"
        ]
    },
    "b_keyed_group_priority_2": {
        "hosts": [
            "host0"
        ]
    },
    "c_static_group_priority_1": {
        "hosts": [
            "host0"
        ]
    }
}
+ grep '"override_priority_1": "c_static_group_priority_1"' out.txt
                "override_priority_1": "c_static_group_priority_1",
+ grep '"override_priority_2": "b_keyed_group_priority_2"' out.txt
                "override_priority_2": "b_keyed_group_priority_2",
+ grep '"override_priority_3": "a_keyed_group_priority_3"' out.txt
                "override_priority_3": "a_keyed_group_priority_3"
```
